### PR TITLE
Start the server on port 5000 on start up.

### DIFF
--- a/hello.pl
+++ b/hello.pl
@@ -18,3 +18,4 @@ reply(Request) :-
         bagof(DiprocheReturn, diproche_fo(ProposedProof, DiprocheReturn), Returns),
 		write('List of Lists with unverified Input: '), write(Returns).
 
+?-server(5000).


### PR DESCRIPTION
This should simplify things and only opening the file is required now to start the server.
Previously the user had to type server(5000).